### PR TITLE
Validar CPF/CNPJ igual para payer

### DIFF
--- a/grails-app/domain/cobra/customer/Customer.groovy
+++ b/grails-app/domain/cobra/customer/Customer.groovy
@@ -4,6 +4,10 @@ import cobra.base.BasePerson
 
 class Customer extends BasePerson {
 
+    static mapping = {
+        cpfCnpj unique: true
+    }
+
     static namedQueries = {
         query { Map search ->
             if (!Boolean.valueOf(search.includeDeleted)) {

--- a/grails-app/services/cobra/payer/PayerService.groovy
+++ b/grails-app/services/cobra/payer/PayerService.groovy
@@ -31,7 +31,8 @@ class PayerService {
 
 
     public void save(Customer customer, Map params){
-        validateParams(params, customer)
+        validateParams(params)
+        validateCpfCnpj(customer, params.cpfCnpj as String)
 
         Payer payer = new Payer()
         payer.name = params.name
@@ -89,7 +90,7 @@ class PayerService {
         payer.save(failOnError: true)
     }
 
-    private void validateParams(Map params, Customer customer) {
+    private void validateParams(Map params) {
         if (!params.name) {
             throw new BusinessException("Nome é obrigatório")
         }

--- a/src/main/groovy/cobra/base/BasePerson.groovy
+++ b/src/main/groovy/cobra/base/BasePerson.groovy
@@ -18,10 +18,6 @@ abstract class BasePerson extends BaseDomain {
     String city
     String state
 
-    static mapping = {
-        cpfCnpj unique: true
-    }
-
     static constraints = {
         name blank: false
         email blank: false, email: true


### PR DESCRIPTION
- Alterando cpfCnpj Unique de BasePerson para Customer pois dois payer podem ter o mesmo CPF desde que tenham customers diferentes 