### PR TITLE
Viacep form create

### DIFF
--- a/grails-app/assets/javascripts/postalCodeUtils.js
+++ b/grails-app/assets/javascripts/postalCodeUtils.js
@@ -1,0 +1,21 @@
+function searchAddress(event) {
+    const postalCode = $(event.target).val()
+    const validPostalCode = /^([0-9]{8})$/
+
+    if (!validPostalCode.test(postalCode)) {
+        alert("CEP inválido!")
+        return
+    }
+
+    $.getJSON("https://viacep.com.br/ws/"+ postalCode +"/json/?callback=?", function(dados) {
+        if (!("erro" in dados)) {
+            $(event.target.form.streetName).val(dados.logradouro).prop( "disabled", false )
+            $(event.target.form.neighborhood).val(dados.bairro).prop( "disabled", false )
+            $(event.target.form.city).val(dados.localidade).prop( "disabled", false )
+            $(event.target.form.state).val(dados.uf).prop( "disabled", false )
+        }
+        else {
+            alert("CEP não encontrado.")
+        }
+    })
+}

--- a/grails-app/views/payer/index.gsp
+++ b/grails-app/views/payer/index.gsp
@@ -112,7 +112,7 @@
                             </div>
 
                             <div class="mb-3 form-floating">
-                                <g:field class="form-control" type="text" name="streetName" required="true"/>
+                                <g:field class="form-control" type="text" name="streetName" required="true" disabled="true"/>
                                 <label for="streetName">Rua</label>
                             </div>
 
@@ -127,17 +127,17 @@
                             </div>
 
                             <div class="mb-3 form-floating">
-                                <g:field class="form-control" type="text" name="state" required="true"/>
+                                <g:field class="form-control" type="text" name="state" required="true" disabled="true"/>
                                 <label  for="state">Estado</label>
                             </div>
 
                             <div class="mb-3 form-floating">
-                                <g:field class="form-control" type="text" name="city" required="true"/>
+                                <g:field class="form-control" type="text" name="city" required="true" disabled="true"/>
                                 <label for="city">Cidade</label>
                             </div>
 
                             <div class="mb-3 form-floating">
-                                <g:field class="form-control" type="text" name="neighborhood" required="true"/>
+                                <g:field class="form-control" type="text" name="neighborhood" required="true" disabled="true"/>
                                 <label for="neighborhood">Bairro</label>
                             </div>
                             <div class="float-end">
@@ -203,10 +203,34 @@
             }
         })
     }
+
+    function searchAddress(event) {
+        const postalCode = $(event.target).val()
+        const validPostalCode = /^([0-9]{8})$/
+
+        if (!validPostalCode.test(postalCode)) {
+            alert("CEP inválido!")
+            return
+        }
+
+        $.getJSON("https://viacep.com.br/ws/"+ postalCode +"/json/?callback=?", function(dados) {
+            if (!("erro" in dados)) {
+                $("#streetName").val(dados.logradouro).prop( "disabled", false )
+                $("#neighborhood").val(dados.bairro).prop( "disabled", false )
+                $("#city").val(dados.localidade).prop( "disabled", false )
+                $("#state").val(dados.uf).prop( "disabled", false )
+            }
+            else {
+                alert("CEP não encontrado.")
+            }
+        })
+    }
+
     $(document).ready(() => {
         $("#createPayerForm").on("submit", handleFormSubmit)
         $(".restore-button").on("click", handleRestoreClick)
         $(".delete-button").on("click", handleDeleteClick)
+        $("#postalCode").blur(searchAddress)
     })
 </g:javascript>
 </body>

--- a/grails-app/views/payer/index.gsp
+++ b/grails-app/views/payer/index.gsp
@@ -5,6 +5,7 @@
     <asset:stylesheet src="grid-table.css"/>
     <asset:stylesheet src="modal.css"/>
     <title>Index</title>
+    <asset:javascript src="postalCodeUtils.js"/>
 </head>
 
 <body>
@@ -204,33 +205,11 @@
         })
     }
 
-    function searchAddress(event) {
-        const postalCode = $(event.target).val()
-        const validPostalCode = /^([0-9]{8})$/
-
-        if (!validPostalCode.test(postalCode)) {
-            alert("CEP inválido!")
-            return
-        }
-
-        $.getJSON("https://viacep.com.br/ws/"+ postalCode +"/json/?callback=?", function(dados) {
-            if (!("erro" in dados)) {
-                $("#streetName").val(dados.logradouro).prop( "disabled", false )
-                $("#neighborhood").val(dados.bairro).prop( "disabled", false )
-                $("#city").val(dados.localidade).prop( "disabled", false )
-                $("#state").val(dados.uf).prop( "disabled", false )
-            }
-            else {
-                alert("CEP não encontrado.")
-            }
-        })
-    }
-
     $(document).ready(() => {
         $("#createPayerForm").on("submit", handleFormSubmit)
         $(".restore-button").on("click", handleRestoreClick)
         $(".delete-button").on("click", handleDeleteClick)
-        $("#postalCode").blur(searchAddress)
+        $("#postalCode").on("blur", searchAddress)
     })
 </g:javascript>
 </body>

--- a/grails-app/views/register/create.gsp
+++ b/grails-app/views/register/create.gsp
@@ -4,6 +4,7 @@
     <meta name="layout" content="main"/>
     <title>Criar conta</title>
     <asset:stylesheet src="form.css"/>
+    <asset:javascript src="postalCodeUtils.js"/>
 </head>
 
 <body>
@@ -135,31 +136,9 @@
             })
         }
 
-        function searchAddress(event) {
-            const postalCode = $(event.target).val()
-            const validPostalCode = /^([0-9]{8})$/
-
-            if (!validPostalCode.test(postalCode)) {
-                alert("CEP inválido!")
-                return
-            }
-
-            $.getJSON("https://viacep.com.br/ws/"+ postalCode +"/json/?callback=?", function(dados) {
-                if (!("erro" in dados)) {
-                    $("#streetName").val(dados.logradouro).prop( "disabled", false )
-                    $("#neighborhood").val(dados.bairro).prop( "disabled", false )
-                    $("#city").val(dados.localidade).prop( "disabled", false )
-                    $("#state").val(dados.uf).prop( "disabled", false )
-                }
-                else {
-                    alert("CEP não encontrado.")
-                }
-            })
-        }
-
         $(document).ready(() => {
             $("#registerForm").on("submit", handleRegisterSubmit)
-            $("#postalCode").blur(searchAddress)
+            $("#postalCode").on("blur", searchAddress)
         })
     </g:javascript>
 </body>

--- a/grails-app/views/register/create.gsp
+++ b/grails-app/views/register/create.gsp
@@ -59,8 +59,8 @@
 
                 <div class="col-md-8">
                     <div class="mb-3 form-floating">
-                        <g:field class="form-control" type="text" name="streetName" required="true"/>
-                        <label class="col-form-label" for="streetName">Rua</label>
+                        <g:field class="form-control" type="text" name="streetName" required="true" disabled="true"/>
+                        <label class="col-form-label" for="streetName">Rua </label>
                     </div>
                 </div>
 
@@ -80,21 +80,21 @@
 
                 <div class="col-md-4">
                     <div class="mb-3 form-floating">
-                        <g:field class="form-control" type="text" name="neighborhood" required="true"/>
+                        <g:field class="form-control" type="text" name="neighborhood" required="true" disabled="true"/>
                         <label class="col-form-label" for="neighborhood">Bairro</label>
                     </div>
                 </div>
 
                 <div class="col-md-10">
                     <div class="mb-3 form-floating">
-                        <g:field class="form-control" type="text" name="city" required="true"/>
+                        <g:field class="form-control" type="text" name="city" required="true" disabled="true"/>
                         <label class="col-form-label" for="city">Cidade</label>
                     </div>
                 </div>
 
                 <div class="col-md-2">
                     <div class="mb-3 form-floating">
-                        <g:field class="form-control" type="text" name="state" required="true"/>
+                        <g:field class="form-control" type="text" name="state" required="true" disabled="true"/>
                         <label class="col-form-label" for="state">Estado</label>
                     </div>
                 </div>
@@ -132,12 +132,35 @@
                 error: (error) => {
                     alert(error.responseJSON.message)
                 }
-            });
+            })
+        }
+
+        function searchAddress(event) {
+            const postalCode = $(event.target).val()
+            const validPostalCode = /^([0-9]{8})$/
+
+            if (!validPostalCode.test(postalCode)) {
+                alert("CEP inválido!")
+                return
+            }
+
+            $.getJSON("https://viacep.com.br/ws/"+ postalCode +"/json/?callback=?", function(dados) {
+                if (!("erro" in dados)) {
+                    $("#streetName").val(dados.logradouro).prop( "disabled", false )
+                    $("#neighborhood").val(dados.bairro).prop( "disabled", false )
+                    $("#city").val(dados.localidade).prop( "disabled", false )
+                    $("#state").val(dados.uf).prop( "disabled", false )
+                }
+                else {
+                    alert("CEP não encontrado.")
+                }
+            })
         }
 
         $(document).ready(() => {
             $("#registerForm").on("submit", handleRegisterSubmit)
-        });
+            $("#postalCode").blur(searchAddress)
+        })
     </g:javascript>
 </body>
 </html>


### PR DESCRIPTION
Adição de uma requisição para o via CEP ao digitar um CEP nos forms de Registro e criação de Payer. 
Os campos Rua, Bairro, Cidade e Estado ficam desabilitados até o CEP ser digitado onde os mesmos são preenchidos e disponíveis para edição.