### PR TITLE
Classe para requisições Ajax

### DIFF
--- a/grails-app/assets/javascripts/ajax-request.js
+++ b/grails-app/assets/javascripts/ajax-request.js
@@ -74,7 +74,7 @@ class AjaxRequest {
     }
 
     static #buildCloseAlertButton() {
-        const closeButton = $("<button></button>")
+        const closeButton = $("<button type='button'></button>")
 
         closeButton.addClass("btn-close ps-3")
         closeButton.attr("data-bs-dismiss", "alert")

--- a/grails-app/assets/javascripts/ajax-request.js
+++ b/grails-app/assets/javascripts/ajax-request.js
@@ -37,7 +37,7 @@ class AjaxRequest {
 
     static onButtonClick(type, url, data) {
         $.ajax({ type, url, data })
-            .done((data) => location.reload())
+            .done(() => location.reload())
             .fail((error) => {
                 let errorMessage = this.#defaultErrorMessage
 

--- a/grails-app/assets/javascripts/ajax-request.js
+++ b/grails-app/assets/javascripts/ajax-request.js
@@ -1,0 +1,85 @@
+class AjaxRequest {
+
+    static #defaultErrorMessage = "Ocorreu um erro desconhecido"
+    static #successActionTimeout = 1250
+
+    static onFormSubmit(type, url, target, redirectTo) {
+        target.find(".alert").remove()
+
+        $.ajax({
+            type,
+            url,
+            data: target.serialize(),
+            dataType: "json"
+        })
+            .done((data) => {
+                target.prepend(this.#buildAlertElement(data.message, true))
+
+                setTimeout(() => {
+                    if (redirectTo) {
+                        location.replace(redirectTo)
+                        return
+                    }
+
+                    location.reload()
+                }, this.#successActionTimeout)
+            })
+            .fail((error) => {
+                let errorMessage = this.#defaultErrorMessage
+
+                if (error.responseJSON) {
+                    errorMessage = error.responseJSON.message
+                }
+
+                target.prepend(this.#buildAlertElement(errorMessage, false))
+            })
+    }
+
+    static onButtonClick(type, url, data) {
+        $.ajax({ type, url, data })
+            .done((data) => location.reload())
+            .fail((error) => {
+                let errorMessage = this.#defaultErrorMessage
+
+                if (error.responseJSON) {
+                    errorMessage = error.responseJSON.message
+                }
+
+                $("body").append(this.#buildFloatingAlertElement(errorMessage, false))
+            })
+    }
+
+    static #buildAlertElement(message, isSuccess) {
+        const alertElement = $("<div></div>")
+
+        alertElement.addClass("alert")
+        alertElement.text(message)
+
+        if (isSuccess) {
+            alertElement.addClass("alert-success")
+        } else {
+            alertElement.addClass("alert-danger")
+        }
+
+        return alertElement
+    }
+
+    static #buildFloatingAlertElement(message, isSuccess) {
+        const alertElement = this.#buildAlertElement(message, isSuccess)
+
+        alertElement.addClass("alert-dismissible fade show floating-alert")
+        alertElement.append(this.#buildCloseAlertButton())
+
+        return alertElement
+    }
+
+    static #buildCloseAlertButton() {
+        const closeButton = $("<button></button>")
+
+        closeButton.addClass("btn-close ps-3")
+        closeButton.attr("data-bs-dismiss", "alert")
+        closeButton.attr("aria-label", "close")
+
+        return closeButton
+    }
+}

--- a/grails-app/assets/javascripts/application.js
+++ b/grails-app/assets/javascripts/application.js
@@ -8,4 +8,5 @@
 //= require jquery-3.5.1.min
 //= require bootstrap.bundle.min
 //= require select2.min
+//= require ajax-request
 //= require_self

--- a/grails-app/assets/stylesheets/application.css
+++ b/grails-app/assets/stylesheets/application.css
@@ -12,5 +12,6 @@
 *= require select2.min
 *= require select2-bootstrap-5-theme.min
 *= require select2-floating-label
+*= require floating-alert
 *= require_self
 */

--- a/grails-app/assets/stylesheets/floating-alert.css
+++ b/grails-app/assets/stylesheets/floating-alert.css
@@ -1,0 +1,6 @@
+.floating-alert {
+    position: fixed;
+    right: 16px;
+    bottom: 16px;
+    max-width: 466px;
+}


### PR DESCRIPTION
Foi criada a classe `AjaxRequest` para padronizar as requisições com feedback de erros em formulários e botões interativos