### PR TITLE
AjaxRequest Scroll

### DIFF
--- a/grails-app/assets/javascripts/ajax-request.js
+++ b/grails-app/assets/javascripts/ajax-request.js
@@ -33,6 +33,7 @@ class AjaxRequest {
 
                 target.prepend(this.#buildAlertElement(errorMessage, false))
             })
+            .always(() => target[0].scrollIntoView({ behavior: "smooth" }))
     }
 
     static onButtonClick(type, url, data) {


### PR DESCRIPTION
Foi adicionado um evento de scroll para o início do formulário ao fim da requisição, pois em formulários muito grandes os alertas não se destacavam